### PR TITLE
Non uniform grid correction

### DIFF
--- a/Isosurface/js/surfacenets.js
+++ b/Isosurface/js/surfacenets.js
@@ -52,7 +52,7 @@ return function(data, dims) {
     , faces = []
     , n = 0
     , x = new Int32Array(3)
-    , R = new Int32Array([1, (dims[0]+1), (dims[0]+1)*(dims[0]+1)])
+    , R = new Int32Array([1, (dims[0]+1), (dims[0]+1)*(dims[1]+1)])
     , grid = new Float32Array(8)
     , buf_no = 1;
    


### PR DESCRIPTION
After encoutering crash on non uniform grids, it occured that I got a buffer outbound index.
If I'm not mistaken the issue came from the dimension in y not used to compute R array values.
